### PR TITLE
Implement Theme injection

### DIFF
--- a/FBLoginSignUp/FBLoginSignUpApp.swift
+++ b/FBLoginSignUp/FBLoginSignUpApp.swift
@@ -22,6 +22,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 struct FBLoginSignUpApp: App {
   // register app delegate for Firebase setup
   @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+  @State private var theme = Theme()
 
 
   var body: some Scene {
@@ -29,6 +30,7 @@ struct FBLoginSignUpApp: App {
       NavigationView {
         ContentView()
       }
+      .environment(theme)
     }
   }
 }

--- a/FBLoginSignUp/Themes/Theme.swift
+++ b/FBLoginSignUp/Themes/Theme.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+@Observable
+final class Theme: ObservableObject {
+    var loginGradient: LinearGradient
+    var primaryColor: Color
+    var textFieldBackground: Color
+
+    init(
+        loginGradient: LinearGradient = LinearGradient(
+            colors: [Color.red, Color.orange],
+            startPoint: .top,
+            endPoint: .bottom
+        ),
+        primaryColor: Color = .red,
+        textFieldBackground: Color = Color(.secondarySystemBackground)
+    ) {
+        self.loginGradient = loginGradient
+        self.primaryColor = primaryColor
+        self.textFieldBackground = textFieldBackground
+    }
+}

--- a/FBLoginSignUp/Views/EmailLoginView.swift
+++ b/FBLoginSignUp/Views/EmailLoginView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct EmailLoginView: View {
     @Environment(AppStateViewModel.self) private var appState
+    @Environment(Theme.self) private var theme
     @Environment(\ .dismiss) private var dismiss
     @State private var viewModel = EmailLoginViewModel()
     
@@ -64,9 +65,11 @@ struct EmailLoginView: View {
                 Text("A link to reset your password has been sent to \(viewModel.email).")
             }
         )
+        .background(theme.loginGradient)
     }
 }
 #Preview {
     EmailLoginView()
         .environment(AppStateViewModel())
+        .environment(Theme())
 }

--- a/FBLoginSignUp/Views/SignUpView.swift
+++ b/FBLoginSignUp/Views/SignUpView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct SignUpView: View {
     @Environment(AppStateViewModel.self) private var appState
+    @Environment(Theme.self) private var theme
     @Environment(\ .dismiss) private var dismiss
     @State var viewModel = SignUpViewModel()
     
@@ -55,8 +56,10 @@ struct SignUpView: View {
             LoadingOverlay(isLoading: $viewModel.isLoading)
         }
         .errorAlert(errorMessage: $viewModel.errorMessage)
+        .background(theme.loginGradient)
     }
 }
 #Preview {
     SignUpView()
+        .environment(Theme())
 }

--- a/FBLoginSignUp/Views/UserAuthView.swift
+++ b/FBLoginSignUp/Views/UserAuthView.swift
@@ -10,7 +10,8 @@ import AuthenticationServices
 
 struct UserAuthView: View {
     @Environment(AppStateViewModel.self) private var appState
-    
+    @Environment(Theme.self) private var theme
+
     @Environment(\ .dismiss) private var dismiss
     @State private var viewModel = UserAuthViewModel()
     
@@ -85,7 +86,7 @@ struct UserAuthView: View {
             Spacer()
         }
         .padding()
-        .background(Color(.systemBackground))
+        .background(theme.loginGradient)
     }
 }
 
@@ -95,5 +96,6 @@ struct UserAuthView_Previews: PreviewProvider {
             UserAuthView()
         }
         .environment(AppStateViewModel())  // 👈 inject environment manually for preview
+        .environment(Theme())
     }
 }


### PR DESCRIPTION
## Summary
- add a `Theme` class containing colors and gradients
- provide a shared theme in `FBLoginSignUpApp`
- read the theme from environment in `UserAuthView`, `EmailLoginView` and `SignUpView`
- apply `theme.loginGradient` as the background in login and signup screens
- update previews to inject the theme

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685e6f5d7b408320af7e15a07d30aca7